### PR TITLE
Add flag to disable primary View frame change, format code

### DIFF
--- a/Sources/SplitView/HSplit.swift
+++ b/Sources/SplitView/HSplit.swift
@@ -19,21 +19,17 @@ public struct HSplit<P: View, D: View, S: View>: View {
     private let secondary: S
 
     public var body: some View {
-        Split(
-            isResizing: isResizing,
-            primary: { primary },
-            secondary: { secondary }
-        )
-        .layout(LayoutHolder(.horizontal))
-        .styling(styling)
-        .constraints(constraints)
-        .onDrag(onDrag)
-        .splitter {
-            splitter
-                .environmentObject(styling)
-        }
-        .fraction(fraction)
-        .hide(hide)
+        Split(primary: { primary }, secondary: { secondary })
+            .layout(LayoutHolder(.horizontal))
+            .styling(styling)
+            .constraints(constraints)
+            .onDrag(onDrag)
+            .splitter {
+                splitter
+                    .environmentObject(styling)
+            }
+            .fraction(fraction)
+            .hide(hide)
     }
 
     public init(

--- a/Sources/SplitView/HSplit.swift
+++ b/Sources/SplitView/HSplit.swift
@@ -8,38 +8,68 @@
 import SwiftUI
 
 public struct HSplit<P: View, D: View, S: View>: View {
+    private let isResizing: Bool
     private let fraction: FractionHolder
     private let hide: SideHolder
     private let styling: SplitStyling
     private let constraints: SplitConstraints
-    private let onDrag: ((CGFloat)->Void)?
+    private let onDrag: ((CGFloat) -> Void)?
     private let primary: P
     private let splitter: D
     private let secondary: S
-    
+
     public var body: some View {
-        Split(primary: { primary }, secondary: { secondary })
-            .layout(LayoutHolder(.horizontal))
-            .styling(styling)
-            .constraints(constraints)
-            .onDrag(onDrag)
-            .splitter {
-                splitter
-                    .environmentObject(styling)
-            }
-            .fraction(fraction)
-            .hide(hide)
+        Split(
+            isResizing: isResizing,
+            primary: { primary },
+            secondary: { secondary }
+        )
+        .layout(LayoutHolder(.horizontal))
+        .styling(styling)
+        .constraints(constraints)
+        .onDrag(onDrag)
+        .splitter {
+            splitter
+                .environmentObject(styling)
+        }
+        .fraction(fraction)
+        .hide(hide)
     }
-    
-    public init(@ViewBuilder left: @escaping ()->P, @ViewBuilder right: @escaping ()->S) where D == Splitter {
+
+    public init(
+        isResizing: Bool = true,
+        @ViewBuilder left: @escaping () -> P,
+        @ViewBuilder right: @escaping () -> S
+    ) where D == Splitter {
         let fraction = FractionHolder()
         let hide = SideHolder()
         let styling = SplitStyling()
         let constraints = SplitConstraints()
-        self.init(fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: nil, primary: { left() }, splitter: { D() }, secondary: { right() })
+        self.init(
+            isResizing: isResizing,
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: nil,
+            primary: { left() },
+            splitter: { D() },
+            secondary: { right() }
+        )
     }
-    
-    private init(fraction: FractionHolder, hide: SideHolder, styling: SplitStyling, constraints: SplitConstraints, onDrag: ((CGFloat)->Void)?, @ViewBuilder primary: @escaping ()->P, @ViewBuilder splitter: @escaping ()->D, @ViewBuilder secondary: @escaping ()->S) {
+
+    private init(
+        isResizing: Bool,
+        fraction: FractionHolder,
+        hide: SideHolder,
+        styling: SplitStyling,
+        constraints: SplitConstraints,
+        onDrag: ((CGFloat) -> Void)?,
+        @ViewBuilder primary: @escaping () -> P,
+        @ViewBuilder splitter: @escaping () -> D,
+        @ViewBuilder secondary: @escaping () -> S
+    ) {
+        self.isResizing = isResizing
         self.fraction = fraction
         self.hide = hide
         self.styling = styling
@@ -49,48 +79,122 @@ public struct HSplit<P: View, D: View, S: View>: View {
         self.splitter = splitter()
         self.secondary = secondary()
     }
-    
-    //MARK: Modifiers
-    
+
+    // MARK: Modifiers
+
     // Note: Modifiers return a new HSplit instance with the same state except for what is
     // being modified.
-    
+
     /// Return a new HSplit with the `splitter` set to a new type.
     ///
     /// If the splitter is a SplitDivider, get its visibleThickness and set that in `styling` before returning.
-    public func splitter<T>(@ViewBuilder _ splitter: @escaping ()->T) -> HSplit<P, T, S> where T: View {
+    public func splitter<T>(@ViewBuilder _ splitter: @escaping () -> T) -> HSplit<P, T, S> where T: View {
         let newSplitter = splitter()
         if let splitDivider = newSplitter as? (any SplitDivider) {
             styling.visibleThickness = splitDivider.visibleThickness
         }
-        return HSplit<P, T, S>(fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: splitter, secondary: { secondary })
+        return HSplit<P, T, S>(
+            isResizing: isResizing,
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: onDrag,
+            primary: { primary },
+            splitter: splitter,
+            secondary: { secondary }
+        )
     }
-    
+
     /// Return a new instance of HSplit with `constraints` set to these values.
-    public func constraints(minPFraction: CGFloat? = nil, minSFraction: CGFloat? = nil, priority: SplitSide? = nil, dragToHideP: Bool = false, dragToHideS: Bool = false) -> HSplit {
-        let constraints = SplitConstraints(minPFraction: minPFraction, minSFraction: minSFraction, priority: priority, dragToHideP: dragToHideP, dragToHideS: dragToHideS)
-        return HSplit(fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+    public func constraints(
+        minPFraction: CGFloat? = nil,
+        minSFraction: CGFloat? = nil,
+        priority: SplitSide? = nil,
+        dragToHideP: Bool = false,
+        dragToHideS: Bool = false
+    ) -> HSplit {
+        let constraints = SplitConstraints(
+            minPFraction: minPFraction,
+            minSFraction: minSFraction,
+            priority: priority,
+            dragToHideP: dragToHideP,
+            dragToHideS: dragToHideS
+        )
+        return HSplit(
+            isResizing: isResizing,
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: onDrag,
+            primary: { primary },
+            splitter: { splitter },
+            secondary: { secondary }
+        )
     }
-    
+
     /// Return a new instance of HSplit with `onDrag` set to `callback`.
     ///
     /// The `callback` will be executed as `splitter` is dragged, with the current value of `privateFraction`.
     /// Note that `fraction` is different. It is only set when drag ends, and it is used to determine the initial fraction at open.
-    public func onDrag(_ callback: ((CGFloat)->Void)?) -> HSplit {
-        return HSplit(fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: callback, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+    public func onDrag(_ callback: ((CGFloat) -> Void)?) -> HSplit {
+        return HSplit(
+            isResizing: isResizing,
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: callback,
+            primary: { primary },
+            splitter: { splitter },
+            secondary: { secondary }
+        )
     }
-    
+
     /// Return a new instance of HSplit with `styling` set to these values.
-    public func styling(color: Color? = nil, inset: CGFloat? = nil, visibleThickness: CGFloat? = nil, invisibleThickness: CGFloat? = nil, hideSplitter: Bool = false) -> HSplit {
-        let styling = SplitStyling(color: color, inset: inset, visibleThickness: visibleThickness, invisibleThickness: invisibleThickness, hideSplitter: hideSplitter)
-        return HSplit(fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+    public func styling(
+        color: Color? = nil,
+        inset: CGFloat? = nil,
+        visibleThickness: CGFloat? = nil,
+        invisibleThickness: CGFloat? = nil,
+        hideSplitter: Bool = false
+    ) -> HSplit {
+        let styling = SplitStyling(
+            color: color,
+            inset: inset,
+            visibleThickness: visibleThickness,
+            invisibleThickness: invisibleThickness,
+            hideSplitter: hideSplitter
+        )
+        return HSplit(
+            isResizing: isResizing,
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: onDrag,
+            primary: { primary },
+            splitter: { splitter },
+            secondary: { secondary }
+        )
     }
-    
+
     /// Return a new instance of HSplit with `fraction` set to this FractionHolder
     public func fraction(_ fraction: FractionHolder) -> HSplit<P, D, S> {
-        HSplit(fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+        HSplit(
+            isResizing: isResizing,
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: onDrag,
+            primary: { primary },
+            splitter: { splitter },
+            secondary: { secondary }
+        )
     }
-    
+
     /// Return a new instance of HSplit with `fraction` set to a FractionHolder holding onto this CGFloat
     public func fraction(_ fraction: CGFloat) -> HSplit<P, D, S> {
         self.fraction(FractionHolder(fraction))
@@ -98,14 +202,23 @@ public struct HSplit<P: View, D: View, S: View>: View {
 
     /// Return a new instance of HSplit with `hide` set to this SideHolder
     public func hide(_ side: SideHolder) -> HSplit<P, D, S> {
-        HSplit(fraction: fraction, hide: side, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+        HSplit(
+            isResizing: isResizing,
+            fraction: fraction,
+            hide: side,
+            styling: styling,
+            constraints: constraints,
+            onDrag: onDrag,
+            primary: { primary },
+            splitter: { splitter },
+            secondary: { secondary }
+        )
     }
-    
+
     /// Return a new instance of HSplit with `hide` set to a SideHolder holding onto this SplitSide
     public func hide(_ side: SplitSide) -> HSplit<P, D, S> {
-        self.hide(SideHolder(side))
+        hide(SideHolder(side))
     }
-    
 }
 
 struct HSplit_Previews: PreviewProvider {
@@ -124,7 +237,7 @@ struct HSplit_Previews: PreviewProvider {
                 )
             }
         )
-        
+
         HSplit(
             left: {
                 VSplit(top: { Color.red }, bottom: { Color.green })

--- a/Sources/SplitView/Split.swift
+++ b/Sources/SplitView/Split.swift
@@ -17,7 +17,8 @@ import SwiftUI
 /// The same Split view is used regardless of `layout`, since the math is all the same but applied
 /// to width or height depending on whether `layout.isHorizontal` or not.
 public struct Split<P: View, D: View, S: View>: View {
-    
+    /// Whether primary view should be resized or offsett keeping its original frame
+    public let isResizing: Bool
     /// The `primary` View, left when `layout==.horizontal`, top when `layout==.vertical`.
     private let primary: P
     /// The `secondary` View, right when `layout==.horizontal`, bottom when `layout==.vertical`.
@@ -30,7 +31,7 @@ public struct Split<P: View, D: View, S: View>: View {
     /// The constraints within which the splitter can travel and which side if any has priority
     private let constraints: SplitConstraints
     /// Function to execute with `constrainedFraction` as argument during drag
-    private let onDrag: ((CGFloat)->Void)?
+    private let onDrag: ((CGFloat) -> Void)?
     /// The minimum fraction of full width/height that `primary` can occupy
     private let minPFraction: CGFloat?
     /// The minimum fraction of full width/height that `secondary` can occupy
@@ -54,32 +55,49 @@ public struct Split<P: View, D: View, S: View>: View {
     @State private var oldSize: CGSize?
     /// The previous position as we drag the `splitter`
     @State private var previousPosition: CGFloat?
-    
+
     public var body: some View {
         GeometryReader { geometry in
             let horizontal = layout.isHorizontal
             let size = geometry.size
             let width = size.width
             let height = size.height
+
             let length = horizontal ? width : height
             let breadth = horizontal ? height : width
+
             let hidePrimary = sideToHide() == .primary || hide.side == .primary
             let hideSecondary = sideToHide() == .secondary || hide.side == .secondary
+
             let minPLength = length * ((hidePrimary ? 0 : minPFraction) ?? 0)
             let minSLength = length * ((hideSecondary ? 0 : minSFraction) ?? 0)
+
             let pLength = max(minPLength, pLength(in: size))
             let sLength = max(minSLength, sLength(in: size))
+
             let spacing = spacing()
+
             let pWidth = horizontal ? max(minPLength, min(width - spacing, pLength - spacing / 2)) : breadth
             let pHeight = horizontal ? breadth : max(minPLength, min(height - spacing, pLength - spacing / 2))
+
             let sWidth = horizontal ? max(minSLength, min(width - pLength, sLength - spacing / 2)) : breadth
             let sHeight = horizontal ? breadth : max(minSLength, min(height - pLength, sLength - spacing / 2))
+
             let sOffset = horizontal ? CGSize(width: pWidth + spacing, height: 0) : CGSize(width: 0, height: pHeight + spacing)
+            let pOffset = horizontal ? CGSize(width: -(width - sOffset.width) - spacing, height: 0) : CGSize(width: 0, height: -(height - sOffset.height) - spacing)
+
             let dCenter = horizontal ? CGPoint(x: pWidth + spacing / 2, y: height / 2) : CGPoint(x: width / 2, y: pHeight + spacing / 2)
+
             ZStack(alignment: .topLeading) {
                 if !hidePrimary {
-                    primary
-                        .frame(width: pWidth, height: pHeight)
+                    if isResizing {
+                        primary
+                            .frame(width: pWidth, height: pHeight)
+                    } else {
+                        primary
+                            .frame(width: pWidth)
+                            .offset(pOffset)
+                    }
                 }
                 if !hideSecondary {
                     secondary
@@ -101,7 +119,7 @@ public struct Split<P: View, D: View, S: View>: View {
             .task(id: geometry.size) {
                 setConstrainedFraction(in: geometry.size)
             }
-            .clipped()  // Can cause problems in some List styles if not clipped
+            .clipped() // Can cause problems in some List styles if not clipped
             .environmentObject(layout)
             .environmentObject(styling)
         }
@@ -110,18 +128,43 @@ public struct Split<P: View, D: View, S: View>: View {
     /// Public init only allows `primary` and `secondary`, with `splitter` defaulting to Splitter.
     ///
     /// The `layout`, `fraction`,  `hide` ,  `styling`, `constraints`, and any custom `splitter` must be specified using the modifiers if they are not defaults
-    public init(@ViewBuilder primary: @escaping ()->P, @ViewBuilder secondary: @escaping ()->S) where D == Splitter {
+    public init(
+        isResizing: Bool = true,
+        @ViewBuilder primary: @escaping () -> P,
+        @ViewBuilder secondary: @escaping () -> S
+    ) where D == Splitter {
         let layout = LayoutHolder()
         let fraction = FractionHolder()
         let hide = SideHolder()
         let styling = SplitStyling()
         let constraints = SplitConstraints()
-        self.init(layout, fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: nil, primary: { primary() }, splitter: { D() }, secondary: { secondary() })
+        self.init(layout,
+                  isResizing: isResizing,
+                  fraction: fraction,
+                  hide: hide,
+                  styling: styling,
+                  constraints: constraints,
+                  onDrag: nil,
+                  primary: { primary() },
+                  splitter: { D() },
+                  secondary: { secondary() })
     }
-    
+
     /// Private init requires all values for Split state to be specified and is used by the modifiers.
-    private init(_ layout: LayoutHolder, fraction: FractionHolder, hide: SideHolder, styling: SplitStyling, constraints: SplitConstraints, onDrag: ((CGFloat)->Void)?, @ViewBuilder primary: @escaping ()->P, @ViewBuilder splitter: @escaping ()->D, @ViewBuilder secondary: @escaping ()->S) {
+    private init(
+        _ layout: LayoutHolder,
+        isResizing: Bool,
+        fraction: FractionHolder,
+        hide: SideHolder,
+        styling: SplitStyling,
+        constraints: SplitConstraints,
+        onDrag: ((CGFloat) -> Void)?,
+        @ViewBuilder primary: @escaping () -> P,
+        @ViewBuilder splitter: @escaping () -> D,
+        @ViewBuilder secondary: @escaping () -> S
+    ) {
         self.layout = layout
+        self.isResizing = isResizing
         self.fraction = fraction
         self.hide = hide
         self.styling = styling
@@ -130,17 +173,17 @@ public struct Split<P: View, D: View, S: View>: View {
         self.primary = primary()
         self.splitter = splitter()
         self.secondary = secondary()
-        _constrainedFraction = State(initialValue: fraction.value)  // Local fraction updated during drag
-        _fullFraction = State(initialValue: fraction.value)         // Local fraction updated during drag
+        _constrainedFraction = State(initialValue: fraction.value) // Local fraction updated during drag
+        _fullFraction = State(initialValue: fraction.value) // Local fraction updated during drag
         // Constants we use a lot and want to simplify access and avoid recomputing
-        minPFraction = constraints.minPFraction
-        minSFraction = constraints.minSFraction
-        dragToHideP = constraints.minPFraction != nil && constraints.dragToHideP
-        dragToHideS = constraints.minSFraction != nil && constraints.dragToHideS
+        self.minPFraction = constraints.minPFraction
+        self.minSFraction = constraints.minSFraction
+        self.dragToHideP = constraints.minPFraction != nil && constraints.dragToHideP
+        self.dragToHideS = constraints.minSFraction != nil && constraints.dragToHideS
         // If we are using drag-to-hide, then we force styling.hideSplitter to true
         if dragToHideP || dragToHideS { styling.hideSplitter = true }
     }
-    
+
     /// Return the spacing between `primary` and `secondary`, which is occupied by the splitter's `visibleThickness`.
     ///
     /// If we are previewing the hide (i.e., drag-to-hide) or we are using the `hideSplitter` styling and a side is hidden,
@@ -168,17 +211,17 @@ public struct Split<P: View, D: View, S: View>: View {
         let oldLength = horizontal ? oldSize.width : oldSize.height
         let newLength = horizontal ? size.width : size.height
         let delta = newLength - oldLength
-        self.oldSize = size     // Retain even if delta might be zero because layout might change
+        self.oldSize = size // Retain even if delta might be zero because layout might change
         if delta == 0 { return }
         let oldPLength = constrainedFraction * oldLength
         // If holding the primary side constant, the pLength doesn't change
         let newPLength = side.isPrimary ? oldPLength : oldPLength + delta
         let newFraction = newPLength / newLength
         // Always keep the constrainedFraction within bounds of minimums if specified
-        constrainedFraction = min(1 - (minSFraction ?? 0), max((minPFraction ?? 0), newFraction))
+        constrainedFraction = min(1 - (minSFraction ?? 0), max(minPFraction ?? 0, newFraction))
         fraction.value = constrainedFraction
     }
-    
+
     /// The Gesture recognized by the `splitter`.
     ///
     /// The main function of dragging is to modify the `constrainedFraction` and to track `fullFraction`.
@@ -202,7 +245,7 @@ public struct Split<P: View, D: View, S: View>: View {
     private func drag(in size: CGSize) -> some Gesture {
         return DragGesture()
             .onChanged { gesture in
-                unhide(in: size)    // Unhide if the splitter is hidden, but resetting constrainedFraction first
+                unhide(in: size) // Unhide if the splitter is hidden, but resetting constrainedFraction first
                 let fraction = fraction(for: gesture, in: size)
                 constrainedFraction = fraction.constrained
                 fullFraction = fraction.full
@@ -212,7 +255,7 @@ public struct Split<P: View, D: View, S: View>: View {
             }
             .onEnded { gesture in
                 previousPosition = nil
-                styling.previewHide = false     // We are never previewing the hidden state when drag ends
+                styling.previewHide = false // We are never previewing the hidden state when drag ends
                 hide.side = sideToHide()
                 // The fullFraction is used to determine the sideToHide, so we need to reset when done dragging,
                 // but *after* setting the hide.side.
@@ -220,7 +263,7 @@ public struct Split<P: View, D: View, S: View>: View {
                 fraction.value = constrainedFraction
             }
     }
-    
+
     /// Return the side to hide for previewing in the drag-to-hide operation.
     ///
     /// Note a side is not necessarily hidden when `sideToHide` is called.
@@ -236,7 +279,7 @@ public struct Split<P: View, D: View, S: View>: View {
             return nil
         }
     }
-    
+
     /// Return a new value for `constrained` and `full` fractions based on the DragGesture.
     ///
     /// The `constrained` value is always between `minSFraction` and `minPFraction` (if specified).
@@ -245,20 +288,23 @@ public struct Split<P: View, D: View, S: View>: View {
     /// We use a delta based on `previousPosition` so the `splitter` follows the location where drag begins, not
     /// the center of the splitter. This way the drag is smooth from the beginning, rather than jumping the splitter location to
     /// the starting drag point.
-    func fraction(for gesture: DragGesture.Value, in size: CGSize) -> (constrained: CGFloat, full: CGFloat) {
+    func fraction(
+        for gesture: DragGesture.Value,
+        in size: CGSize
+    ) -> (constrained: CGFloat, full: CGFloat) {
         let horizontal = layout.isHorizontal
-        let length = horizontal ? size.width : size.height                                              // Size in direction of dragging
-        let splitterLocation = length * constrainedFraction                                             // Splitter position prior to drag
-        let gestureLocation = horizontal ? gesture.location.x : gesture.location.y                      // Gesture location in direction of dragging
-        let gestureTranslation = horizontal ? gesture.translation.width : gesture.translation.height    // Gesture movement since beginning of drag
-        let delta = previousPosition == nil ? gestureTranslation : gestureLocation - previousPosition!  // Amount moved since last change
-        let constrainedLocation = max(0, min(length, splitterLocation + delta))                         // New location kept in proper bounds
-        let fullFraction = constrainedLocation / length                                                 // Fraction of full size without regard to constraints
-        let constrainedFraction = min(1 - (minSFraction ?? 0), max((minPFraction ?? 0), fullFraction))  // Fraction of full size kept within constraints
+        let length = horizontal ? size.width : size.height // Size in direction of dragging
+        let splitterLocation = length * constrainedFraction // Splitter position prior to drag
+        let gestureLocation = horizontal ? gesture.location.x : gesture.location.y // Gesture location in direction of dragging
+        let gestureTranslation = horizontal ? gesture.translation.width : gesture.translation.height // Gesture movement since beginning of drag
+        let delta = previousPosition == nil ? gestureTranslation : gestureLocation - previousPosition! // Amount moved since last change
+        let constrainedLocation = max(0, min(length, splitterLocation + delta)) // New location kept in proper bounds
+        let fullFraction = constrainedLocation / length // Fraction of full size without regard to constraints
+        let constrainedFraction = min(1 - (minSFraction ?? 0), max(minPFraction ?? 0, fullFraction)) // Fraction of full size kept within constraints
         return (constrained: constrainedFraction, full: fullFraction)
     }
-    
-    /// Return whether the splitter is draggable. 
+
+    /// Return whether the splitter is draggable.
     ///
     /// The splitter becomes non-draggable if `styling.hideSplitter` is `true`
     /// and either side is hidden. It will also be non-draggable when the `primary` side is
@@ -274,7 +320,7 @@ public struct Split<P: View, D: View, S: View>: View {
     /// **Important**: You must provide a means to unhide the side (e.g., a hide/show
     /// button) if your splitter can become non-draggable.
     ///
-    /// On a related note, when you use an invisible splitter, you will typically specify min 
+    /// On a related note, when you use an invisible splitter, you will typically specify min
     /// fractions it has to stay within. If you don't, then it can be dragged to the edge, and
     /// your user will have no visual indication that the other side can be re-exposed by dragging
     /// the invisible splitter out again.
@@ -292,7 +338,7 @@ public struct Split<P: View, D: View, S: View>: View {
             }
         }
     }
-    
+
     /// Unhide before dragging if a side is hidden.
     ///
     /// When we set `hide.size` to nil, the `body` is recomputed based on `constrainedFraction`.
@@ -303,11 +349,11 @@ public struct Split<P: View, D: View, S: View>: View {
         if hide.side != nil {
             let length = layout.isHorizontal ? size.width : size.height
             let pLength = pLength(in: size)
-            constrainedFraction = pLength/length
+            constrainedFraction = pLength / length
             hide.side = nil
         }
     }
-    
+
     /// The length of `primary` in the `layout` direction, without regard to any inset for the Splitter
     private func pLength(in size: CGSize) -> CGFloat {
         let length = layout.isHorizontal ? size.width : size.height
@@ -321,7 +367,7 @@ public struct Split<P: View, D: View, S: View>: View {
             }
         }
     }
-    
+
     /// The length of `secondary` in the `layout` direction, without regard to any inset for the Splitter
     private func sLength(in size: CGSize) -> CGFloat {
         let length = layout.isHorizontal ? size.width : size.height
@@ -335,86 +381,184 @@ public struct Split<P: View, D: View, S: View>: View {
             }
         }
     }
-    
-    //MARK: Modifiers
-    
+
+    // MARK: Modifiers
+
     /// Return a new Split with the `splitter` set to a new type.
     ///
     /// If the splitter is a SplitDivider, then get its `visibleThickness` and set it in `styling` before returning.
-    public func splitter<T>(@ViewBuilder _ splitter: @escaping ()->T) -> Split<P, T, S> where T: View {
+    public func splitter<T>(@ViewBuilder _ splitter: @escaping () -> T) -> Split<P, T, S> where T: View {
         let newSplitter = splitter()
         if let splitDivider = newSplitter as? (any SplitDivider) {
             styling.visibleThickness = splitDivider.visibleThickness
         }
-        return Split<P, T, S>(layout, fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: splitter, secondary: { secondary })
+        return Split<P, T, S>(layout,
+                              isResizing: isResizing,
+                              fraction: fraction,
+                              hide: hide,
+                              styling: styling,
+                              constraints: constraints,
+                              onDrag: onDrag,
+                              primary: { primary },
+                              splitter: splitter,
+                              secondary: { secondary })
     }
-    
+
     /// Return a new instance of Split with `constraints` set to a SplitConstraints holding these values.
-    public func constraints(minPFraction: CGFloat? = nil, minSFraction: CGFloat? = nil, priority: SplitSide? = nil, dragToHideP: Bool = false, dragToHideS: Bool = false) -> Split {
-        let constraints = SplitConstraints(minPFraction: minPFraction, minSFraction: minSFraction, priority: priority, dragToHideP: dragToHideP, dragToHideS: dragToHideS)
-        return Split(layout, fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+    public func constraints(
+        minPFraction: CGFloat? = nil,
+        minSFraction: CGFloat? = nil,
+        priority: SplitSide? = nil,
+        dragToHideP: Bool = false,
+        dragToHideS: Bool = false
+    ) -> Split {
+        let constraints = SplitConstraints(
+            minPFraction: minPFraction,
+            minSFraction: minSFraction,
+            priority: priority,
+            dragToHideP: dragToHideP,
+            dragToHideS: dragToHideS
+        )
+        return Split(layout,
+                     isResizing: isResizing,
+                     fraction: fraction,
+                     hide: hide,
+                     styling: styling,
+                     constraints: constraints,
+                     onDrag: onDrag,
+                     primary: { primary },
+                     splitter: { splitter },
+                     secondary: { secondary })
     }
-    
+
     /// Return a new instance of Split with `constraints` set to this SplitConstraints.
     ///
     /// This is a convenience method for HSplit and VSplit.
     public func constraints(_ constraints: SplitConstraints) -> Split {
-        self.constraints(minPFraction: constraints.minPFraction, minSFraction: constraints.minSFraction, priority: constraints.priority, dragToHideP: constraints.dragToHideP, dragToHideS: constraints.dragToHideS)
+        self.constraints(
+            minPFraction: constraints.minPFraction,
+            minSFraction: constraints.minSFraction,
+            priority: constraints.priority,
+            dragToHideP: constraints.dragToHideP,
+            dragToHideS: constraints.dragToHideS
+        )
     }
-    
+
     /// Return a new instance of Split with `onDrag` set to `callback`.
     ///
     /// The `callback` will be executed as `splitter` is dragged, with the current value of `constrainedFraction`.
     /// Note that `fraction` is different. It is only set when drag ends, and it is used to determine the initial fraction at open.
     ///
     /// This is a convenience method for HSplit and VSplit.
-    public func onDrag(_ callback: ((CGFloat)->Void)?) -> Split {
-        return Split(layout, fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: callback, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+    public func onDrag(_ callback: ((CGFloat) -> Void)?) -> Split {
+        return Split(layout,
+                     isResizing: isResizing,
+                     fraction: fraction,
+                     hide: hide,
+                     styling: styling,
+                     constraints: constraints,
+                     onDrag: callback,
+                     primary: { primary },
+                     splitter: { splitter },
+                     secondary: { secondary })
     }
-    
+
     /// Return a new instance of Split with `styling` set to a SplitStyling holding these values.
     ///
     /// This is a convenience method for `Splitter.line()` which is also used by `Splitter.invisible()`.
-    public func styling(color: Color? = nil, inset: CGFloat? = nil, visibleThickness: CGFloat? = nil, invisibleThickness: CGFloat? = nil, hideSplitter: Bool = false) -> Split {
-        let styling = SplitStyling(color: color, inset: inset, visibleThickness: visibleThickness, invisibleThickness: invisibleThickness, hideSplitter: hideSplitter)
-        return Split(layout, fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+    public func styling(
+        color: Color? = nil,
+        inset: CGFloat? = nil,
+        visibleThickness: CGFloat? = nil,
+        invisibleThickness: CGFloat? = nil,
+        hideSplitter: Bool = false
+    ) -> Split {
+        let styling = SplitStyling(
+            color: color,
+            inset: inset,
+            visibleThickness: visibleThickness,
+            invisibleThickness: invisibleThickness,
+            hideSplitter: hideSplitter
+        )
+        return Split(layout,
+                     isResizing: isResizing,
+                     fraction: fraction,
+                     hide: hide,
+                     styling: styling,
+                     constraints: constraints,
+                     onDrag: onDrag,
+                     primary: { primary },
+                     splitter: { splitter },
+                     secondary: { secondary })
     }
-    
+
     /// Return a new instance of Split with `styling` set to this SplitStyling.
     ///
     /// This is a convenience method for HSplit and VSplit.
     public func styling(_ styling: SplitStyling) -> Split {
-        self.styling(color: styling.color, inset: styling.inset, visibleThickness: styling.visibleThickness, invisibleThickness: styling.invisibleThickness, hideSplitter: styling.hideSplitter)
+        self.styling(
+            color: styling.color,
+            inset: styling.inset,
+            visibleThickness: styling.visibleThickness,
+            invisibleThickness: styling.invisibleThickness,
+            hideSplitter: styling.hideSplitter
+        )
     }
-    
+
     /// Return a new instance of Split with `layout` set to this LayoutHolder.
     ///
     /// Split only supports `layout` specified using a LayoutHolder because if you are not going
     /// to change the `layout`, then you should just use HSplit or VSplit.
     public func layout(_ layout: LayoutHolder) -> Split {
-        Split(layout, fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+        Split(layout,
+              isResizing: isResizing,
+              fraction: fraction,
+              hide: hide,
+              styling: styling,
+              constraints: constraints,
+              onDrag: onDrag,
+              primary: { primary },
+              splitter: { splitter },
+              secondary: { secondary })
     }
-    
+
     /// Return a new instance of Split with `fraction` set to this FractionHolder.
     public func fraction(_ fraction: FractionHolder) -> Split {
-        Split(layout, fraction: fraction, hide: hide, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+        Split(layout,
+              isResizing: isResizing,
+              fraction: fraction,
+              hide: hide,
+              styling: styling,
+              constraints: constraints,
+              onDrag: onDrag,
+              primary: { primary },
+              splitter: { splitter },
+              secondary: { secondary })
     }
-    
+
     /// Return a new instance of Split with `fraction` set to a FractionHolder holding onto this CGFloat.
     public func fraction(_ fraction: CGFloat) -> Split {
         self.fraction(FractionHolder(fraction))
     }
-    
+
     /// Return a new instance of Split with `hide` set to this SideHolder.
     public func hide(_ side: SideHolder) -> Split {
-        Split(layout, fraction: fraction, hide: side, styling: styling, constraints: constraints, onDrag: onDrag, primary: { primary }, splitter: { splitter }, secondary: { secondary })
+        Split(layout,
+              isResizing: isResizing,
+              fraction: fraction,
+              hide: side,
+              styling: styling,
+              constraints: constraints,
+              onDrag: onDrag,
+              primary: { primary },
+              splitter: { splitter },
+              secondary: { secondary })
     }
-    
+
     /// Return a new instance of Split with `hide` set to a SideHolder holding onto this SplitSide.
     public func hide(_ side: SplitSide) -> Split {
-        self.hide(SideHolder(side))
+        hide(SideHolder(side))
     }
-    
 }
 
 struct Split_Previews: PreviewProvider {
@@ -436,7 +580,7 @@ struct Split_Previews: PreviewProvider {
             }
         )
         .layout(LayoutHolder(.horizontal))
-        
+
         Split(
             primary: {
                 Split(primary: { Color.red }, secondary: { Color.green })

--- a/Sources/SplitView/Split.swift
+++ b/Sources/SplitView/Split.swift
@@ -94,9 +94,15 @@ public struct Split<P: View, D: View, S: View>: View {
                         primary
                             .frame(width: pWidth, height: pHeight)
                     } else {
-                        primary
-                            .frame(width: pWidth)
-                            .offset(pOffset)
+                        if horizontal {
+                            primary
+                                .frame(height: pHeight)
+                                .offset(pOffset)
+                        } else {
+                            primary
+                                .frame(width: pWidth)
+                                .offset(pOffset)
+                        }
                     }
                 }
                 if !hideSecondary {
@@ -129,7 +135,6 @@ public struct Split<P: View, D: View, S: View>: View {
     ///
     /// The `layout`, `fraction`,  `hide` ,  `styling`, `constraints`, and any custom `splitter` must be specified using the modifiers if they are not defaults
     public init(
-        isResizing: Bool = true,
         @ViewBuilder primary: @escaping () -> P,
         @ViewBuilder secondary: @escaping () -> S
     ) where D == Splitter {
@@ -138,6 +143,7 @@ public struct Split<P: View, D: View, S: View>: View {
         let hide = SideHolder()
         let styling = SplitStyling()
         let constraints = SplitConstraints()
+        let isResizing = true
         self.init(layout,
                   isResizing: isResizing,
                   fraction: fraction,
@@ -539,6 +545,20 @@ public struct Split<P: View, D: View, S: View>: View {
     /// Return a new instance of Split with `fraction` set to a FractionHolder holding onto this CGFloat.
     public func fraction(_ fraction: CGFloat) -> Split {
         self.fraction(FractionHolder(fraction))
+    }
+
+    /// Returns new instance of Split with `isResizing` set to boolean value
+    public func disableResizing(_ value: Bool) -> Split {
+        Split(layout,
+              isResizing: !value,
+              fraction: fraction,
+              hide: hide,
+              styling: styling,
+              constraints: constraints,
+              onDrag: onDrag,
+              primary: { primary },
+              splitter: { splitter },
+              secondary: { secondary })
     }
 
     /// Return a new instance of Split with `hide` set to this SideHolder.

--- a/Sources/SplitView/VSplit.swift
+++ b/Sources/SplitView/VSplit.swift
@@ -8,36 +8,32 @@
 import SwiftUI
 
 public struct VSplit<P: View, D: View, S: View>: View {
-    private let isResizing: Bool
     private let fraction: FractionHolder
     private let hide: SideHolder
     private let styling: SplitStyling
     private let constraints: SplitConstraints
     private let onDrag: ((CGFloat) -> Void)?
+    private let isResizing: Bool
     private let primary: P
     private let splitter: D
     private let secondary: S
 
     public var body: some View {
-        Split(
-            isResizing: isResizing,
-            primary: { primary },
-            secondary: { secondary }
-        )
-        .layout(LayoutHolder(.vertical))
-        .styling(styling)
-        .constraints(constraints)
-        .onDrag(onDrag)
-        .splitter {
-            splitter
-                .environmentObject(styling)
-        }
-        .fraction(fraction)
-        .hide(hide)
+        Split(primary: { primary }, secondary: { secondary })
+            .layout(LayoutHolder(.vertical))
+            .styling(styling)
+            .constraints(constraints)
+            .onDrag(onDrag)
+            .splitter {
+                splitter
+                    .environmentObject(styling)
+            }
+            .fraction(fraction)
+            .hide(hide)
+            .disableResizing(isResizing)
     }
 
     public init(
-        isResizing: Bool = true,
         @ViewBuilder top: @escaping () -> P,
         @ViewBuilder bottom: @escaping () -> S
     ) where D == Splitter {
@@ -45,34 +41,37 @@ public struct VSplit<P: View, D: View, S: View>: View {
         let hide = SideHolder()
         let styling = SplitStyling()
         let constraints = SplitConstraints()
-        self.init(isResizing: isResizing,
-                  fraction: fraction,
-                  hide: hide,
-                  styling: styling,
-                  constraints: constraints,
-                  onDrag: nil,
-                  primary: { top() },
-                  splitter: { D() },
-                  secondary: { bottom() })
+        let isResizing = true
+        self.init(
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: nil,
+            isResizing: isResizing,
+            primary: { top() },
+            splitter: { D() },
+            secondary: { bottom() }
+        )
     }
 
     private init(
-        isResizing: Bool,
         fraction: FractionHolder,
         hide: SideHolder,
         styling: SplitStyling,
         constraints: SplitConstraints,
         onDrag: ((CGFloat) -> Void)?,
+        isResizing: Bool,
         @ViewBuilder primary: @escaping () -> P,
         @ViewBuilder splitter: @escaping () -> D,
         @ViewBuilder secondary: @escaping () -> S
     ) {
-        self.isResizing = isResizing
         self.fraction = fraction
         self.hide = hide
         self.styling = styling
         self.constraints = constraints
         self.onDrag = onDrag
+        self.isResizing = isResizing
         self.primary = primary()
         self.splitter = splitter()
         self.secondary = secondary()
@@ -92,22 +91,26 @@ public struct VSplit<P: View, D: View, S: View>: View {
             styling.visibleThickness = splitDivider.visibleThickness
         }
         return VSplit<P, T, S>(
-            isResizing: isResizing,
             fraction: fraction,
             hide: hide,
             styling: styling,
             constraints: constraints,
             onDrag: onDrag,
-            primary: {
-                primary
-            },
+            isResizing: isResizing,
+            primary: { primary },
             splitter: splitter,
             secondary: { secondary }
         )
     }
 
     /// Return a new instance of VSplit with `constraints` set to these values.
-    public func constraints(minPFraction: CGFloat? = nil, minSFraction: CGFloat? = nil, priority: SplitSide? = nil, dragToHideP: Bool = false, dragToHideS: Bool = false) -> VSplit {
+    public func constraints(
+        minPFraction: CGFloat? = nil,
+        minSFraction: CGFloat? = nil,
+        priority: SplitSide? = nil,
+        dragToHideP: Bool = false,
+        dragToHideS: Bool = false
+    ) -> VSplit {
         let constraints = SplitConstraints(
             minPFraction: minPFraction,
             minSFraction: minSFraction,
@@ -116,12 +119,12 @@ public struct VSplit<P: View, D: View, S: View>: View {
             dragToHideS: dragToHideS
         )
         return VSplit(
-            isResizing: isResizing,
             fraction: fraction,
             hide: hide,
             styling: styling,
             constraints: constraints,
             onDrag: onDrag,
+            isResizing: isResizing,
             primary: { primary },
             splitter: { splitter },
             secondary: { secondary }
@@ -134,12 +137,12 @@ public struct VSplit<P: View, D: View, S: View>: View {
     /// Note that `fraction` is different. It is only set when drag ends, and it is used to determine the initial fraction at open.
     public func onDrag(_ callback: ((CGFloat) -> Void)?) -> VSplit {
         return VSplit(
-            isResizing: isResizing,
             fraction: fraction,
             hide: hide,
             styling: styling,
             constraints: constraints,
             onDrag: callback,
+            isResizing: isResizing,
             primary: { primary },
             splitter: { splitter },
             secondary: { secondary }
@@ -147,15 +150,27 @@ public struct VSplit<P: View, D: View, S: View>: View {
     }
 
     ///  Return a new instance of VSplit with `styling` set to these values.
-    public func styling(color: Color? = nil, inset: CGFloat? = nil, visibleThickness: CGFloat? = nil, invisibleThickness: CGFloat? = nil, hideSplitter: Bool = false) -> VSplit {
-        let styling = SplitStyling(color: color, inset: inset, visibleThickness: visibleThickness, invisibleThickness: invisibleThickness, hideSplitter: hideSplitter)
+    public func styling(
+        color: Color? = nil,
+        inset: CGFloat? = nil,
+        visibleThickness: CGFloat? = nil,
+        invisibleThickness: CGFloat? = nil,
+        hideSplitter: Bool = false
+    ) -> VSplit {
+        let styling = SplitStyling(
+            color: color,
+            inset: inset,
+            visibleThickness: visibleThickness,
+            invisibleThickness: invisibleThickness,
+            hideSplitter: hideSplitter
+        )
         return VSplit(
-            isResizing: isResizing,
             fraction: fraction,
             hide: hide,
             styling: styling,
             constraints: constraints,
             onDrag: onDrag,
+            isResizing: isResizing,
             primary: { primary },
             splitter: { splitter },
             secondary: { secondary }
@@ -165,12 +180,12 @@ public struct VSplit<P: View, D: View, S: View>: View {
     /// Return a new instance of VSplit with `fraction` set to this FractionHolder
     public func fraction(_ fraction: FractionHolder) -> VSplit<P, D, S> {
         VSplit(
-            isResizing: isResizing,
             fraction: fraction,
             hide: hide,
             styling: styling,
             constraints: constraints,
             onDrag: onDrag,
+            isResizing: isResizing,
             primary: { primary },
             splitter: { splitter },
             secondary: { secondary }
@@ -185,12 +200,12 @@ public struct VSplit<P: View, D: View, S: View>: View {
     /// Return a new instance of VSplit with `hide` set to this SideHolder
     public func hide(_ side: SideHolder) -> VSplit<P, D, S> {
         VSplit(
-            isResizing: isResizing,
             fraction: fraction,
             hide: side,
             styling: styling,
             constraints: constraints,
             onDrag: onDrag,
+            isResizing: isResizing,
             primary: { primary },
             splitter: { splitter },
             secondary: { secondary }
@@ -200,6 +215,23 @@ public struct VSplit<P: View, D: View, S: View>: View {
     /// Return a new instance of VSplit with `hide` set to a SideHolder holding onto this SplitSide
     public func hide(_ side: SplitSide) -> VSplit<P, D, S> {
         hide(SideHolder(side))
+    }
+
+    /// Omitts setting the height (if vertical) or width (if horizontal) that matches the container frame
+    /// May result in unexpected behaviour, as it's main goal is to keep content at it's original size,
+    /// outside of the view frame if required
+    public func disableResizing(_ value: Bool = true) -> VSplit<P, D, S> {
+        VSplit(
+            fraction: fraction,
+            hide: hide,
+            styling: styling,
+            constraints: constraints,
+            onDrag: onDrag,
+            isResizing: value,
+            primary: { primary },
+            splitter: { splitter },
+            secondary: { secondary }
+        )
     }
 }
 


### PR DESCRIPTION
Changes mentioned in #22.
Actual logic change is in `Split.swift` file, HSplit and VSplit were just updated to reduce long horizontal lines and pass `isResizing` flag.